### PR TITLE
Fix package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "repository": "https://github.com/mavenlink/mavenlint.git",
   "license": "MIT",
   "devDependencies": {
-    "eslint": ">= 3.7.0",
+    "eslint": "^3.7.0",
     "eslint-plugin-import": "^1.13.0",
     "eslint-plugin-jsx-a11y": "^2.1.0",
     "eslint-plugin-react": "^6.1.2"
   },
   "peerDependencies": {
-    "eslint": ">= 3.7.0",
+    "eslint": "^3.7.0",
     "eslint-plugin-import": "^1.13.0",
     "eslint-plugin-jsx-a11y": "^2.1.0",
     "eslint-plugin-react": "^6.1.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-mavenlint",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Mavenlink ESLint config",
   "main": "index.js",
   "repository": "https://github.com/mavenlink/mavenlint.git",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "eslint-plugin-react": "^6.1.2"
   },
   "peerDependencies": {
-    "eslint": "^3.7.0",
+    "eslint": ">= 3.7.0",
     "eslint-plugin-import": "^1.13.0",
     "eslint-plugin-jsx-a11y": "^2.1.0",
     "eslint-plugin-react": "^6.1.2"

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   },
   "peerDependencies": {
     "eslint": ">= 3.7.0",
-    "eslint-plugin-import": "^1.13.0",
-    "eslint-plugin-jsx-a11y": "^2.1.0",
-    "eslint-plugin-react": "^6.1.2"
+    "eslint-plugin-import": ">= 1.13.0",
+    "eslint-plugin-jsx-a11y": ">= 2.1.0",
+    "eslint-plugin-react": ">= 6.1.2"
   },
   "dependencies": {
     "eslint-config-airbnb": "^10.0.1"

--- a/package.json
+++ b/package.json
@@ -5,13 +5,19 @@
   "main": "index.js",
   "repository": "https://github.com/mavenlink/mavenlint.git",
   "license": "MIT",
-  "peerDependencies": {
-    "eslint": ">= 3.7.0"
-  },
-  "dependencies": {
-    "eslint-config-airbnb": "^10.0.1",
+  "devDependencies": {
+    "eslint": ">= 3.7.0",
     "eslint-plugin-import": "^1.13.0",
     "eslint-plugin-jsx-a11y": "^2.1.0",
     "eslint-plugin-react": "^6.1.2"
+  },
+  "peerDependencies": {
+    "eslint": ">= 3.7.0",
+    "eslint-plugin-import": "^1.13.0",
+    "eslint-plugin-jsx-a11y": "^2.1.0",
+    "eslint-plugin-react": "^6.1.2"
+  },
+  "dependencies": {
+    "eslint-config-airbnb": "^10.0.1"
   }
 }


### PR DESCRIPTION
`npm install` was outputting peer dependency warnings which seem to be the cause of using it in standalone repos. Follows how https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb extends https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base

Fixes https://github.com/mavenlink/mavenlint/issues/4