### PR TITLE
Make console calls errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports = {
     'arrow-body-style': 'off',
     'func-names': 'off',
     'react/jsx-boolean-value': 'off',
+    'no-console': 'error',
     'no-multiple-empty-lines': ["error", { "max": 1 }],
     'no-return-assign': ['error', 'except-parens'],
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-mavenlint",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Mavenlink ESLint config",
   "main": "index.js",
   "repository": "https://github.com/mavenlink/mavenlint.git",


### PR DESCRIPTION
AirBnb defaults them to warnings which are masked in CI. Any console calls made should be exceptions which warrant a manual disable