### PR TITLE
No return assign

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,5 @@ module.exports = {
     'react/jsx-boolean-value': 'off',
     'no-console': 'error',
     'no-multiple-empty-lines': ["error", { "max": 1 }],
-    'no-return-assign': ['error', 'except-parens'],
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-mavenlint",
-  "version": "2.2.2-alpha.1",
+  "version": "2.2.2",
   "description": "Mavenlink ESLint config",
   "main": "index.js",
   "repository": "https://github.com/mavenlink/mavenlint.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-mavenlint",
-  "version": "2.2.1",
+  "version": "2.2.2-alpha.1",
   "description": "Mavenlink ESLint config",
   "main": "index.js",
   "repository": "https://github.com/mavenlink/mavenlint.git",


### PR DESCRIPTION
@juanca, @naganowl, can you take a look at this, please? This remove the no-return-assign rule override. The rule still applies to our codebase.

Corresponds to https://github.com/mavenlink/mavenlink/pull/10996