### PR TITLE
Css composition rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ Install dependencies for all packages by running the following from the root of 
 yarn install
 ```
 
-To publish changed packages, first login to NPM:
+To publish changed packages, first login:
 
 ```
-npm login
+yarn login
 ```
 
 To publish alpha versions for testing in other applications, run:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,13 @@ To publish changed packages, first login to NPM:
 npm login
 ```
 
-and then run:
+To publish alpha versions for testing in other applications, run:
+
+```
+yarn publish-canary
+```
+
+To publish release versions, run:
 
 ```
 yarn publish-packages

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "packages/*"
   ],
   "scripts": {
+    "publish-canary": "lerna publish --canary --npm-client=npm --registry=https://registry.npmjs.org/",
     "publish-packages": "lerna publish --npm-client=npm --registry=https://registry.npmjs.org/",
     "test": "jest"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "babel-preset-es2015": "^6.24.1",
     "eslint": "^4.14.0",
     "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-jsx-a11y": "^ 5.1.1",
+    "eslint-plugin-jsx-a11y": "^5.1.1",
     "eslint-plugin-react": "^7.5.1",
     "jest": "^22.0.6",
     "lerna": "^2.7.1",

--- a/packages/eslint-config-mavenlint/index.js
+++ b/packages/eslint-config-mavenlint/index.js
@@ -21,5 +21,6 @@ module.exports = {
     'no-console': 'error',
     'no-multiple-empty-lines': ["error", { "max": 1 }],
     'mavenlint/use-flux-standard-actions': 'error',
+    'mavenlint/use-css-composition': 'error',
   }
 };

--- a/packages/eslint-plugin-mavenlint/index.js
+++ b/packages/eslint-plugin-mavenlint/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   rules: {
+    'use-css-composition': require('./rules/use-css-composition'),
     'use-flux-standard-actions': require('./rules/use-flux-standard-actions'),
   },
 };

--- a/packages/eslint-plugin-mavenlint/rules/__tests__/use-css-composition-spec.js
+++ b/packages/eslint-plugin-mavenlint/rules/__tests__/use-css-composition-spec.js
@@ -1,0 +1,35 @@
+import { RuleTester } from 'eslint';
+import rule from '../use-css-composition';
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+ruleTester.run('use-css-composition', rule, {
+  valid: [
+    // Static string class.
+    {
+      code: 'function test() { return <span className="great" />; }',
+    },
+    // Variable class.
+    {
+      code: 'function test() { return <span className={styles.span} />; }',
+    },
+    // No class.
+    {
+      code: 'function test() { return <span />; }',
+    },
+  ],
+  invalid: [
+    // Interpolated class.
+    {
+      code: 'function test() { return <span className={`btn ${foo}`} />; }',
+      errors: [{ type: 'JSXAttribute' }],
+    }
+  ],
+});

--- a/packages/eslint-plugin-mavenlint/rules/use-css-composition.js
+++ b/packages/eslint-plugin-mavenlint/rules/use-css-composition.js
@@ -1,0 +1,30 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'use CSS composition instead of string interpolation for class names',
+      category: 'Best Practices',
+    },
+  },
+  create(context) {
+    return {
+      JSXAttribute(node) {
+        // Is this a classname property?
+        const identifier = node.name;
+        if (identifier.name !== 'className') { return; }
+
+        // Is the value an expression, as opposed to a literal?
+        const value = node.value;
+        if (!value.expression) { return; }
+
+        // Is the expression a template literal?
+        const expression = value.expression;
+        if (expression.type === 'TemplateLiteral') {
+          context.report({
+            node,
+            message: 'Use CSS composition instead of string interpolation to DRY up styles',
+          });
+        }
+      }
+    };
+  },
+}

--- a/packages/eslint-plugin-mavenlint/rules/use-flux-standard-actions.js
+++ b/packages/eslint-plugin-mavenlint/rules/use-flux-standard-actions.js
@@ -6,7 +6,6 @@ module.exports = {
       description: 'enforce using flux standard actions',
       category: 'Best Practices',
     },
-    schema: [],
   },
   create(context) {
     return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1378,7 +1378,7 @@ eslint-plugin-import@^2.8.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
-"eslint-plugin-jsx-a11y@^ 5.1.1":
+eslint-plugin-jsx-a11y@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-5.1.1.tgz#5c96bb5186ca14e94db1095ff59b3e2bd94069b1"
   dependencies:


### PR DESCRIPTION
@juanca, can you take a look at this when you get a chance, please? This adds a rule preventing string interpolation for classNames.

I expect that backfilling will need to be done in Mavenlink.

Also note that version numbers don't need to be bumped, as our publishing process will take care of that.