### PR TITLE
Bump lerna

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "publish": {
       "ignore": [
         "*.md",
-        "**/__tests__/**"
+        "*-spec.js"
       ]
     }
   },

--- a/lerna.json
+++ b/lerna.json
@@ -8,7 +8,7 @@
     }
   },
   "independent": true,
-  "lerna": "2.7.0",
+  "lerna": "2.7.1",
   "npmClient": "yarn",
   "packages": [
     "packages/*"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "packages/*"
   ],
   "scripts": {
-    "publish-packages": "lerna publish --npm-client=npm --registry=https://registry.npmjs.org/",
+    "publish-packages": "lerna publish",
     "test": "jest"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "eslint-plugin-jsx-a11y": "^ 5.1.1",
     "eslint-plugin-react": "^7.5.1",
     "jest": "^22.0.6",
-    "lerna": "^2.7.0",
+    "lerna": "^2.7.1",
     "regenerator-runtime": "^0.11.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2720,9 +2720,9 @@ left-pad@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.2.0.tgz#d30a73c6b8201d8f7d8e7956ba9616087a68e0ee"
 
-lerna@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/lerna/-/lerna-2.7.0.tgz#1df22aebaa82d8134b19303ac3e503146d1e4e9a"
+lerna@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/lerna/-/lerna-2.7.1.tgz#abd536376eca5e9f41a6d611da5b744534ef906f"
   dependencies:
     async "^1.5.0"
     chalk "^2.1.0"
@@ -3385,7 +3385,16 @@ randomatic@^1.1.3:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
+rc@^1.0.1, rc@^1.1.6:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.4.tgz#a0f606caae2a3b862bbd0ef85482c0125b315fa3"
+  dependencies:
+    deep-extend "~0.4.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
+
+rc@^1.1.7:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.3.tgz#51575a900f8dd68381c710b4712c2154c3e2035b"
   dependencies:
@@ -3688,9 +3697,13 @@ sax@^1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
+
+semver@^5.0.1, semver@^5.1.0, semver@^5.4.1:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -4121,9 +4134,13 @@ uuid@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
-uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
+uuid@^3.0.0, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+
+uuid@^3.0.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Bumps lerna to 2.7.1 to resolve an issue that was forcing us to use npm instead of yarn for publishing. https://github.com/lerna/lerna/pull/1204