### PR TITLE
Enforce models inheriting from ApplicationRecord

### DIFF
--- a/lib/mavenlint.rb
+++ b/lib/mavenlint.rb
@@ -1,1 +1,2 @@
 require 'rubocop/cop/mavenlint/unsafe-mass-assignment'
+require 'rubocop/cop/mavenlint/use-application-record'

--- a/lib/rubocop/cop/mavenlint/use-application-record.rb
+++ b/lib/rubocop/cop/mavenlint/use-application-record.rb
@@ -1,0 +1,32 @@
+require 'rubocop'
+
+module RuboCop
+  module Cop
+    module Mavenlint
+      # Enforce models inheriting from ApplicationRecord instead of ActiveRecord::Base
+      #
+      # For example
+      #
+      #   class SomeModel < ActiveRecord::Base
+      #   end
+      #
+      # should be
+      #
+      #   class SomeModel < ApplicationRecord
+      #   end
+      #
+      # Note that this cop is built in to RuboCop. However, it only runs on Rails 5, and we want
+      # run it even though we're on Rails 4. Once we're on Rails 5, however, we should be able to
+      # remove this custom cop and enable the built-in one.
+      # @see https://github.com/bbatsov/rubocop/blob/10a7041d23bcd579821b378dd351aeead7c3f082/lib/rubocop/cop/rails/application_record.rb
+      #
+      class UseApplicationRecord < RuboCop::Cop::Cop
+        MSG = 'Models should subclass `ApplicationRecord`.'.freeze
+        SUPERCLASS = 'ApplicationRecord'.freeze
+        BASE_PATTERN = '(const (const nil? :ActiveRecord) :Base)'.freeze
+
+        include RuboCop::Cop::EnforceSuperclass
+      end
+    end
+  end
+end

--- a/mavenlint.gemspec
+++ b/mavenlint.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "mavenlint"
-  s.version     = "1.1.1"
+  s.version     = "1.2.0"
   s.licenses    = ["MIT"]
   s.summary     = "Mavenlink Rubocop config"
   s.authors     = ["Mavenlnk"]

--- a/spec/rubocop/cop/mavenlint/use_application_record_spec.rb
+++ b/spec/rubocop/cop/mavenlint/use_application_record_spec.rb
@@ -1,0 +1,26 @@
+require 'rubocop/cop/mavenlint/use-application-record'
+require 'spec_helper'
+
+RSpec.describe RuboCop::Cop::Mavenlint::UseApplicationRecord do
+  let(:config) { RuboCop::Config.new }
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense a model directly inherits from ActiveRecord::Base' do
+    expect_offense(<<~RUBY)
+      class User < ActiveRecord::Base; end
+                   ^^^^^^^^^^^^^^^^^^ Models should subclass `ApplicationRecord`.
+    RUBY
+  end
+
+  it 'passes when a model inherits from ApplicationRecord' do
+    expect_no_offenses(<<~RUBY)
+      class User < ApplicationRecord; end
+    RUBY
+  end
+
+  it 'passes when a model inherits from an other class' do
+    expect_no_offenses(<<~RUBY)
+      class User < SuperUserSuperClass; end
+    RUBY
+  end
+end


### PR DESCRIPTION
Corresponds to https://github.com/mavenlink/mavenlink/pull/11963 and https://github.com/mavenlink/rfc/pull/64.

Will enforce that models inherit from `ApplicationRecord` which will have model-level security checks in it, instead of `ActiveRecord::Base`.

Note that this rule is built-in to Rubocop, but only runs on Rails 5. Once we upgrade, we should remove this custom rule and enable the built-in one.