### PR TITLE
Add .log to standard actions

### DIFF
--- a/packages/eslint-plugin-mavenlint/rules/__tests__/use-flux-standard-actions-spec.js
+++ b/packages/eslint-plugin-mavenlint/rules/__tests__/use-flux-standard-actions-spec.js
@@ -25,6 +25,11 @@ ruleTester.run('use-flux-standard-actions', rule, {
       code: 'function test() { return function (dispatch) { dispatch({ foo: "BAR" }); } }',
       filename: 'lib/action-creators/foo.js',
     },
+    // log property.
+    {
+      code: 'function test() { return { type: "FOO", log: true }; }',
+      filename: 'lib/action-creators/foo.js',
+    },
   ],
   invalid: [
     // Basic case with a non compliant property.

--- a/packages/eslint-plugin-mavenlint/rules/use-flux-standard-actions.js
+++ b/packages/eslint-plugin-mavenlint/rules/use-flux-standard-actions.js
@@ -1,4 +1,4 @@
-const standardKeys = ['error', 'meta', 'payload', 'type'];
+const standardKeys = ['error', 'meta', 'payload', 'type', 'log'];
 
 module.exports = {
   meta: {


### PR DESCRIPTION
This allows us to use `.log` in our actions introduced in this PR: https://github.com/mavenlink/mavenlink/pull/12441