### PR TITLE
Add rule to detect when jasmineEnzyme should not be used

### DIFF
--- a/packages/eslint-config-mavenlint/index.js
+++ b/packages/eslint-config-mavenlint/index.js
@@ -22,6 +22,7 @@ module.exports = {
     'no-multiple-empty-lines': ["error", { "max": 1 }],
     'mavenlint/use-flux-standard-actions': 'error',
     'mavenlint/use-css-composition': 'error',
+    'mavenlint/no-unnecessary-jasmine-enzyme': 'error',
     'jasmine/no-focused-tests': 'error',
   }
 };

--- a/packages/eslint-plugin-mavenlint/index.js
+++ b/packages/eslint-plugin-mavenlint/index.js
@@ -2,5 +2,6 @@ module.exports = {
   rules: {
     'use-css-composition': require('./rules/use-css-composition'),
     'use-flux-standard-actions': require('./rules/use-flux-standard-actions'),
+    'no-unnecessary-jasmine-enzyme': require('./rules/no-unnecessary-jasmine-enzyme'),
   },
 };

--- a/packages/eslint-plugin-mavenlint/rules/__tests__/no-unnecessary-jasmine-enzyme-spec.js
+++ b/packages/eslint-plugin-mavenlint/rules/__tests__/no-unnecessary-jasmine-enzyme-spec.js
@@ -24,6 +24,20 @@ ruleTester.run('no-unnecessary-jasmine-enzyme', rule, {
       filename: 'spec/foobar-spec.jsx',
     },
     {
+      // Invoking jasmineEnzyme AND using a negated matcher.
+      code: [
+        'describe("tests", () => {',
+        '  beforeEach(() => {',
+        '    jasmineEnzyme();',
+        '  });',
+        '  it("is true", () => {',
+        '    expect(true).not.toBeEmptyRender();',
+        '  });',
+        '});',
+      ].join('\n'),
+      filename: 'spec/foobar-spec.jsx',
+    },
+    {
       // Jasmine enzyme NOT invoked.
       code: [
         'describe("tests", () => {',

--- a/packages/eslint-plugin-mavenlint/rules/__tests__/no-unnecessary-jasmine-enzyme-spec.js
+++ b/packages/eslint-plugin-mavenlint/rules/__tests__/no-unnecessary-jasmine-enzyme-spec.js
@@ -1,0 +1,55 @@
+import { RuleTester } from 'eslint';
+import rule from '../no-unnecessary-jasmine-enzyme';
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+  },
+});
+
+ruleTester.run('no-unnecessary-jasmine-enzyme', rule, {
+  valid: [
+    {
+      // Invoking jasmineEnzyme AND using one of its matchers.
+      code: [
+        'describe("tests", () => {',
+        '  beforeEach(() => {',
+        '    jasmineEnzyme();',
+        '  });',
+        '  it("is true", () => {',
+        '    expect(true).toBeChecked();',
+        '  });',
+        '});',
+      ].join('\n'),
+      filename: 'spec/foobar-spec.jsx',
+    },
+    {
+      // Jasmine enzyme NOT invoked.
+      code: [
+        'describe("tests", () => {',
+        '  it("is true", () => {',
+        '    expect(true).toBeChecked(true);',
+        '  });',
+        '});',
+      ].join('\n'),
+      filename: 'spec/foobar-spec.jsx',
+    }
+  ],
+  invalid: [
+    {
+      // Invoking jasmineEnzyme without using any of its matchers.
+      code: [
+        'describe("tests", () => {',
+        '  beforeEach(() => {',
+        '    jasmineEnzyme();',
+        '  });',
+        '  it("is true", () => {',
+        '    expect(true).toEqual(true);',
+        '  });',
+        '});',
+      ].join('\n'),
+      filename: 'spec/foobar-spec.jsx',
+      errors: [{ type: 'CallExpression' }],
+    }
+  ],
+});

--- a/packages/eslint-plugin-mavenlint/rules/no-unnecessary-jasmine-enzyme.js
+++ b/packages/eslint-plugin-mavenlint/rules/no-unnecessary-jasmine-enzyme.js
@@ -35,16 +35,13 @@ module.exports = {
         if (node.callee.name === 'jasmineEnzyme') {
           setupNodes.push(node);
         }
+      },
 
-        // Find assertions. These are calls to `expect` followed by accessing a property on the result.
-        if (node.callee.name === 'expect' && node.parent.type === 'MemberExpression') {
-          // Get the name of the accessed property (for example, toEqual).
-          const matcherName = node.parent.property.name;
-          // Determine if the property is one of the enzyme-matchers.
-          const isEnzymeMatcher = enzymeMatchers.includes(matcherName);
-          if (isEnzymeMatcher && !usesEnzymeMatchers) {
-            usesEnzymeMatchers = true;
-          }
+      MemberExpression(node) {
+        const isEnzymeMatcher = enzymeMatchers.includes(node.property.name);
+
+        if (isEnzymeMatcher && !usesEnzymeMatchers) {
+          usesEnzymeMatchers = true;
         }
       },
 

--- a/packages/eslint-plugin-mavenlint/rules/no-unnecessary-jasmine-enzyme.js
+++ b/packages/eslint-plugin-mavenlint/rules/no-unnecessary-jasmine-enzyme.js
@@ -1,0 +1,64 @@
+const enzymeMatchers = [
+  'toBeChecked',
+  'toBeDisabled',
+  'toBeEmptyRender',
+  'toExist',
+  'toContainReact',
+  'toHaveClassName',
+  'toHaveHTML',
+  'toHaveProp',
+  'toHaveRef',
+  'toHaveState',
+  'toHaveStyle',
+  'toHaveTagName',
+  'toHaveText',
+  'toIncludeText',
+  'toHaveValue',
+  'toMatchElement',
+  'toMatchSelector',
+];
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'do not allow setting up jasmine enzyme if it is not being used',
+      category: 'Best Practices',
+    },
+  },
+  create(context) {
+    const setupNodes = [];
+    let usesEnzymeMatchers = false;
+
+    return {
+      CallExpression(node) {
+        // Find everywhere jasmineEnzyme was setup.
+        if (node.callee.name === 'jasmineEnzyme') {
+          setupNodes.push(node);
+        }
+
+        // Find assertions. These are calls to `expect` followed by accessing a property on the result.
+        if (node.callee.name === 'expect' && node.parent.type === 'MemberExpression') {
+          // Get the name of the accessed property (for example, toEqual).
+          const matcherName = node.parent.property.name;
+          // Determine if the property is one of the enzyme-matchers.
+          const isEnzymeMatcher = enzymeMatchers.includes(matcherName);
+          if (isEnzymeMatcher && !usesEnzymeMatchers) {
+            usesEnzymeMatchers = true;
+          }
+        }
+      },
+
+      'Program:exit': function () {
+        // Determine if jasmineEnzyme was setup and we _don't_ use one of its matchers.
+        if (setupNodes.length > 0 && !usesEnzymeMatchers) {
+          setupNodes.forEach(function (node) {
+            context.report({
+              node,
+              message: 'jasmineEnzyme setup, but never used.',
+            });
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-mavenlint/rules/no-unnecessary-jasmine-enzyme.js
+++ b/packages/eslint-plugin-mavenlint/rules/no-unnecessary-jasmine-enzyme.js
@@ -1,8 +1,9 @@
 const enzymeMatchers = [
   'toBeChecked',
   'toBeDisabled',
+  'toBeEmpty',
   'toBeEmptyRender',
-  'toExist',
+  'toBePresent',
   'toContainReact',
   'toHaveClassName',
   'toHaveHTML',

--- a/packages/eslint-plugin-mavenlint/rules/no-unnecessary-jasmine-enzyme.js
+++ b/packages/eslint-plugin-mavenlint/rules/no-unnecessary-jasmine-enzyme.js
@@ -1,9 +1,8 @@
 const enzymeMatchers = [
   'toBeChecked',
   'toBeDisabled',
-  'toBeEmpty',
   'toBeEmptyRender',
-  'toBePresent',
+  'toExist',
   'toContainReact',
   'toHaveClassName',
   'toHaveHTML',

--- a/packages/eslint-plugin-mavenlint/rules/no-unnecessary-jasmine-enzyme.js
+++ b/packages/eslint-plugin-mavenlint/rules/no-unnecessary-jasmine-enzyme.js
@@ -38,9 +38,14 @@ module.exports = {
       },
 
       MemberExpression(node) {
+        // Go no further if we already know we're using enzyme matchers.
+        if (usesEnzymeMatchers) {
+          return;
+        }
+
         const isEnzymeMatcher = enzymeMatchers.includes(node.property.name);
 
-        if (isEnzymeMatcher && !usesEnzymeMatchers) {
+        if (isEnzymeMatcher) {
           usesEnzymeMatchers = true;
         }
       },

--- a/packages/eslint-plugin-mavenlint/rules/no-unnecessary-jasmine-enzyme.js
+++ b/packages/eslint-plugin-mavenlint/rules/no-unnecessary-jasmine-enzyme.js
@@ -46,7 +46,7 @@ module.exports = {
       },
 
       'Program:exit': function () {
-        // Determine if jasmineEnzyme was setup and we _don't_ use one of its matchers.
+        // Determine if jasmineEnzyme was setup but we _didn't_ use any of its matchers.
         if (setupNodes.length > 0 && !usesEnzymeMatchers) {
           setupNodes.forEach(function (node) {
             context.report({


### PR DESCRIPTION
This rule detects when:
- `jasmineEnzyme` is invoked in a test.
- But there are none of its matchers being used.

@juanca @brandonduff @jasonwc @ryandhaase can you take a look at this, please?

Corresponds to https://github.com/mavenlink/mavenlink/pull/13592 on the app-side. Also note that https://astexplorer.net/ was really helpful in making this.