### PR TITLE
Do not allow extraneous dependencies

### DIFF
--- a/packages/eslint-config-mavenlint/index.js
+++ b/packages/eslint-config-mavenlint/index.js
@@ -2,10 +2,7 @@ module.exports = {
   extends: 'airbnb',
   plugins: ['mavenlint', 'jasmine'],
   rules: {
-    'import/no-extraneous-dependencies': [
-      'off',
-      { devDependencies: true, optionalDependencies: false, peerDependencies: false },
-    ],
+    'import/no-extraneous-dependencies': 'error',
     'import/no-unresolved': 'off',
     'max-len': ['error', {
       code: 120,

--- a/packages/eslint-config-mavenlint/index.js
+++ b/packages/eslint-config-mavenlint/index.js
@@ -2,7 +2,6 @@ module.exports = {
   extends: 'airbnb',
   plugins: ['mavenlint', 'jasmine'],
   rules: {
-    'import/no-extraneous-dependencies': 'error',
     'import/no-unresolved': 'off',
     'max-len': ['error', {
       code: 120,


### PR DESCRIPTION
Turn back on the rule for not allowing importing dependencies that are not in our package.json. Not sure if this rule was intended to be turned off or not, but we want it back on now.

Note that by default it **_will_** allow us to import dev dependencies, which is important for our tests.

@juanca and @naganowl and @a-bates can you take a look at this, please?