### PR TITLE
Do not allow extraneous dependencies

### DIFF
--- a/packages/eslint-config-mavenlint/index.js
+++ b/packages/eslint-config-mavenlint/index.js
@@ -2,10 +2,7 @@ module.exports = {
   extends: 'airbnb',
   plugins: ['mavenlint', 'jasmine'],
   rules: {
-    'import/no-extraneous-dependencies': [
-      'off',
-      { devDependencies: true, optionalDependencies: false, peerDependencies: false },
-    ],
+    'import/no-extraneous-dependencies': 'error',
     'import/no-unresolved': 'off',
     'max-len': ['error', {
       code: 120,


### PR DESCRIPTION
Follow up to #25 and #26, this adds linting to **_not_** allow extraneous dependencies (dependencies not listed in the package.json).