### PR TITLE
Revert "Do not allow extraneous dependencies"

### DIFF
--- a/packages/eslint-config-mavenlint/index.js
+++ b/packages/eslint-config-mavenlint/index.js
@@ -2,7 +2,10 @@ module.exports = {
   extends: 'airbnb',
   plugins: ['mavenlint', 'jasmine'],
   rules: {
-    'import/no-extraneous-dependencies': 'error',
+    'import/no-extraneous-dependencies': [
+      'off',
+      { devDependencies: true, optionalDependencies: false, peerDependencies: false },
+    ],
     'import/no-unresolved': 'off',
     'max-len': ['error', {
       code: 120,


### PR DESCRIPTION
Reverts mavenlink/mavenlint#27

Follow up to #25, #26, and #27 . I've definitely mismanaged this change, and there's also something I don't understand about implementing/configuring this rule.

Also, a couple bad versions have gotten published by me (0.2.8 and 0.2.9). I will deprecate those versions, publish this new "good" version (without the rule in question turned on), and will quit merging PRs in here without testing them in an actual app, first.