### PR TITLE
Separate out a React config

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ How to use the Mavenlint lint rules for Javascript or Ruby projects.
 
 ### Javascript
 
-Install the Mavenlint ESLint configuration as a dev dependency.
+Install one of the Mavenlint ESLint configurations as a dev dependency.
 
 ```bash
 yarn add eslint-config-mavenlint --dev
@@ -32,6 +32,8 @@ Then, extend `mavenlint` in your `.eslintrc` file.
   "extends": "mavenlint"
 }
 ```
+
+For React linting use `eslint-config-mavenlint-react` and `mavenlint-react` instead.
 
 ### Ruby
 

--- a/packages/eslint-config-mavenlint-react/index.js
+++ b/packages/eslint-config-mavenlint-react/index.js
@@ -1,0 +1,10 @@
+module.exports = {
+  extends: 'mavenlint',
+  plugins: ['mavenlint'],
+  rules: {
+    'react/jsx-boolean-value': 'off',
+    'mavenlint/use-flux-standard-actions': 'error',
+    'mavenlint/use-css-composition': 'error',
+    'mavenlint/no-unnecessary-jasmine-enzyme': 'error',
+  },
+};

--- a/packages/eslint-config-mavenlint-react/package.json
+++ b/packages/eslint-config-mavenlint-react/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "eslint-config-mavenlint-react",
+  "version": "0.0.0",
+  "description": "Mavenlink React ESLint config",
+  "main": "index.js",
+  "repository": "https://github.com/mavenlink/mavenlint.git",
+  "license": "MIT",
+  "peerDependencies": {
+    "eslint": ">=4.14.0",
+    "eslint-plugin-jsx-a11y": ">= 5.1.1",
+    "eslint-plugin-react": ">=7.5.1"
+  },
+  "dependencies": {
+    "eslint-config-mavenlint": "2.9.1",
+    "eslint-plugin-mavenlint": "^0.4.1"
+  }
+}

--- a/packages/eslint-config-mavenlint/index.js
+++ b/packages/eslint-config-mavenlint/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: 'airbnb',
-  plugins: ['mavenlint', 'jasmine'],
+  plugins: ['jasmine'],
   rules: {
     'import/no-extraneous-dependencies': [
       'off',
@@ -17,12 +17,8 @@ module.exports = {
     'no-unused-expressions': ['error', { allowTernary: true }],
     'arrow-body-style': 'off',
     'func-names': 'off',
-    'react/jsx-boolean-value': 'off',
     'no-console': 'error',
     'no-multiple-empty-lines': ["error", { "max": 1 }],
-    'mavenlint/use-flux-standard-actions': 'error',
-    'mavenlint/use-css-composition': 'error',
-    'mavenlint/no-unnecessary-jasmine-enzyme': 'error',
     'jasmine/no-focused-tests': 'error',
-  }
+  },
 };

--- a/packages/eslint-config-mavenlint/package.json
+++ b/packages/eslint-config-mavenlint/package.json
@@ -7,13 +7,10 @@
   "license": "MIT",
   "peerDependencies": {
     "eslint": ">=4.14.0",
-    "eslint-plugin-import": ">=2.8.0",
-    "eslint-plugin-jsx-a11y": ">= 5.1.1",
-    "eslint-plugin-react": ">=7.5.1"
+    "eslint-plugin-import": ">=2.8.0"
   },
   "dependencies": {
     "eslint-config-airbnb": "15.1.0",
-    "eslint-plugin-jasmine": "^2.9.3",
-    "eslint-plugin-mavenlint": "^0.4.1"
+    "eslint-plugin-jasmine": "^2.9.3"
   }
 }


### PR DESCRIPTION
So that we can use our lint rules on non-React projects, separate out a React lint configuration from the "normal" lint rules.

Now there will be:
- eslint-config-mavenlint
- eslint-config-mavenlint-react

Currently it's setup so that using the "react" config also brings along the "normal" config, so you only have to setup one of them.