### PR TITLE
Allow functions to be used before they are defined

### DIFF
--- a/packages/eslint-config-mavenlint/index.js
+++ b/packages/eslint-config-mavenlint/index.js
@@ -20,6 +20,7 @@ module.exports = {
     'react/jsx-boolean-value': 'off',
     'no-console': 'error',
     'no-multiple-empty-lines': ["error", { "max": 1 }],
+    'no-use-before-define': ["error", { "functions": false, "classes": true }],
     'mavenlint/use-flux-standard-actions': 'error',
     'mavenlint/use-css-composition': 'error',
     'mavenlint/no-unnecessary-jasmine-enzyme': 'error',


### PR DESCRIPTION
- We sometimes skip this rule
- It seems to match how most languages (including Ruby) work.
- It allows us to follow the step-down rule in ES6 classes
  https://dzone.com/articles/the-stepdown-rule
- It is considered "safe" since function declaration are hoisted anyway
  https://eslint.org/docs/rules/no-use-before-define#options