### PR TITLE
Exit early when the return statement is empty

### DIFF
--- a/packages/eslint-plugin-mavenlint/rules/__tests__/use-flux-standard-actions-spec.js
+++ b/packages/eslint-plugin-mavenlint/rules/__tests__/use-flux-standard-actions-spec.js
@@ -30,6 +30,11 @@ ruleTester.run('use-flux-standard-actions', rule, {
       code: 'function test() { return { type: "FOO", log: true }; }',
       filename: 'lib/action-creators/foo.js',
     },
+    // thunk with empty return.
+    {
+      code: 'function test() { return function (dispatch) { return; } }',
+      filename: 'lib/action-creators/foo.js',
+    },
   ],
   invalid: [
     // Basic case with a non compliant property.
@@ -37,6 +42,6 @@ ruleTester.run('use-flux-standard-actions', rule, {
       code: 'function test() { return { type: "FOO", data: "BAR" } }',
       filename: 'lib/action-creators/foo.js',
       errors: [{ type: 'ReturnStatement' }],
-    }
+    },
   ],
 });

--- a/packages/eslint-plugin-mavenlint/rules/use-flux-standard-actions.js
+++ b/packages/eslint-plugin-mavenlint/rules/use-flux-standard-actions.js
@@ -14,8 +14,12 @@ module.exports = {
         const path = context.getFilename();
         if (!path.includes('action-creators')) { return; }
 
-        // Is this return value an Object literal?
         const statement = node.argument;
+
+        // Is the return statement empty
+        if (!statement) { return; }
+
+        // Is this return value an Object literal?
         if (statement.type !== 'ObjectExpression') { return; }
 
         // Does this Object have a `type` property? If so, infer that this is an action.


### PR DESCRIPTION
Resolves [#35 use-flux-standard-actions linter crashes when no return value](https://github.com/mavenlink/mavenlint/issues/35)