### PR TITLE
Add a linter to ensure controllers inherit from application controller

### DIFF
--- a/lib/mavenlint.rb
+++ b/lib/mavenlint.rb
@@ -1,4 +1,5 @@
 require 'rubocop/cop/mavenlint/unsafe_mass_assignment'
 require 'rubocop/cop/mavenlint/use_application_record'
 require 'rubocop/cop/mavenlint/use_application_controller'
+require 'rubocop/cop/mavenlint/use_api_controller'
 require 'rubocop/cop/mavenlint/use_fast_capybara_matchers'

--- a/lib/mavenlint.rb
+++ b/lib/mavenlint.rb
@@ -1,3 +1,4 @@
 require 'rubocop/cop/mavenlint/unsafe_mass_assignment'
 require 'rubocop/cop/mavenlint/use_application_record'
+require 'rubocop/cop/mavenlint/use_application_controller'
 require 'rubocop/cop/mavenlint/use_fast_capybara_matchers'

--- a/lib/rubocop/cop/mavenlint/use_api_controller.rb
+++ b/lib/rubocop/cop/mavenlint/use_api_controller.rb
@@ -3,11 +3,11 @@ require 'rubocop'
 module RuboCop
   module Cop
     module Mavenlint
-      # Enforce Api controllers inheriting from ApiController instead of ActionController::Base
+      # Enforce Api controllers inheriting from ApiController instead of ApplicationController
       #
       # For example
       #
-      #   class SomeApiController < ActionController::Base
+      #   class SomeApiController < ApplicationController
       #   end
       #
       # should be
@@ -16,9 +16,9 @@ module RuboCop
       #   end
       #
       class UseApiController < RuboCop::Cop::Cop
-        MSG = 'Controllers should subclass `ApiController`.'.freeze
+        MSG = 'Api Controllers should subclass `ApiController`.'.freeze
         SUPERCLASS = 'ApiController'.freeze
-        BASE_PATTERN = '(const (const nil? :ActionController) :Base)'.freeze
+        BASE_PATTERN = '(const nil? :ApplicationController)'.freeze
 
         include RuboCop::Cop::EnforceSuperclass
       end

--- a/lib/rubocop/cop/mavenlint/use_api_controller.rb
+++ b/lib/rubocop/cop/mavenlint/use_api_controller.rb
@@ -1,0 +1,27 @@
+require 'rubocop'
+
+module RuboCop
+  module Cop
+    module Mavenlint
+      # Enforce Api controllers inheriting from ApiController instead of ActionController::Base
+      #
+      # For example
+      #
+      #   class SomeApiController < ActionController::Base
+      #   end
+      #
+      # should be
+      #
+      #   class SomeApiController < ApiController
+      #   end
+      #
+      class UseApiController < RuboCop::Cop::Cop
+        MSG = 'Controllers should subclass `ApiController`.'.freeze
+        SUPERCLASS = 'ApiController'.freeze
+        BASE_PATTERN = '(const (const nil? :ActionController) :Base)'.freeze
+
+        include RuboCop::Cop::EnforceSuperclass
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/mavenlint/use_application_controller.rb
+++ b/lib/rubocop/cop/mavenlint/use_application_controller.rb
@@ -1,0 +1,27 @@
+require 'rubocop'
+
+module RuboCop
+  module Cop
+    module Mavenlint
+      # Enforce models inheriting from ApplicationController instead of ActionController::Base
+      #
+      # For example
+      #
+      #   class SomeController < ActionController::Base
+      #   end
+      #
+      # should be
+      #
+      #   class SomeController < ApplicationController
+      #   end
+      #
+      class UseApplicationController < RuboCop::Cop::Cop
+        MSG = 'Controllers should subclass `ApplicationController`.'.freeze
+        SUPERCLASS = 'ApplicationController'.freeze
+        BASE_PATTERN = '(const (const nil? :ApplicationController) :Base)'.freeze
+
+        include RuboCop::Cop::EnforceSuperclass
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/mavenlint/use_application_controller.rb
+++ b/lib/rubocop/cop/mavenlint/use_application_controller.rb
@@ -3,7 +3,7 @@ require 'rubocop'
 module RuboCop
   module Cop
     module Mavenlint
-      # Enforce models inheriting from ApplicationController instead of ActionController::Base
+      # Enforce controllers inheriting from ApplicationController instead of ActionController::Base
       #
       # For example
       #
@@ -18,7 +18,7 @@ module RuboCop
       class UseApplicationController < RuboCop::Cop::Cop
         MSG = 'Controllers should subclass `ApplicationController`.'.freeze
         SUPERCLASS = 'ApplicationController'.freeze
-        BASE_PATTERN = '(const (const nil? :ApplicationController) :Base)'.freeze
+        BASE_PATTERN = '(const (const nil? :ActionController) :Base)'.freeze
 
         include RuboCop::Cop::EnforceSuperclass
       end

--- a/mavenlint.gemspec
+++ b/mavenlint.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "mavenlint"
-  s.version     = "1.3.0"
+  s.version     = "1.4.0"
   s.licenses    = ["MIT"]
   s.summary     = "Mavenlink Rubocop config"
   s.authors     = ["Mavenlnk"]

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -67,3 +67,8 @@ Mavenlint/UseFastCapybaraMatchers:
 Mavenlint/UseApiController:
   Include:
     - engines/api/app/controllers/**/*.rb
+    -
+# Only run our controller checks in the controller directory
+Mavenlint/UseApplicationController:
+  Include:
+    - app/controllers/**/*.rb

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -62,3 +62,8 @@ Mavenlint/UseFastCapybaraMatchers:
   Include:
     - spec/selenium/**/*.rb
     - spec/features/**/*.rb
+
+# Only run our Api controller checks in the api controller directory
+Mavenlint/UseApiController:
+  Include:
+    - engines/api/app/controllers/**/*.rb

--- a/spec/rubocop/cop/mavenlint/use_api_controller_spec.rb
+++ b/spec/rubocop/cop/mavenlint/use_api_controller_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe RuboCop::Cop::Mavenlint::UseApiController do
   let(:config) { RuboCop::Config.new }
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense when an api controller directly inherits from ActionController::Base' do
+  it 'registers an offense when an api controller directly inherits from ApplicationController' do
     expect_offense(<<~RUBY)
-      class MyController < ActionController::Base; end
-                           ^^^^^^^^^^^^^^^^^^^^^^ Controllers should subclass `ApiController`.
+      class MyController < ApplicationController; end
+                           ^^^^^^^^^^^^^^^^^^^^^ Api Controllers should subclass `ApiController`.
     RUBY
   end
 
@@ -18,7 +18,7 @@ RSpec.describe RuboCop::Cop::Mavenlint::UseApiController do
     RUBY
   end
 
-  it 'passes when an aoi controller inherits from an other class' do
+  it 'passes when an api controller inherits from another class' do
     expect_no_offenses(<<~RUBY)
       class ApiController < CoolerApiController; end
     RUBY

--- a/spec/rubocop/cop/mavenlint/use_api_controller_spec.rb
+++ b/spec/rubocop/cop/mavenlint/use_api_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rubocop/cop/mavenlint/use_api_controller'
+require 'spec_helper'
+
+RSpec.describe RuboCop::Cop::Mavenlint::UseApiController do
+  let(:config) { RuboCop::Config.new }
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when an api controller directly inherits from ActionController::Base' do
+    expect_offense(<<~RUBY)
+      class MyController < ActionController::Base; end
+                           ^^^^^^^^^^^^^^^^^^^^^^ Controllers should subclass `ApiController`.
+    RUBY
+  end
+
+  it 'passes when an api controller inherits from ApiController' do
+    expect_no_offenses(<<~RUBY)
+      class MyController < ApiController; end
+    RUBY
+  end
+
+  it 'passes when an aoi controller inherits from an other class' do
+    expect_no_offenses(<<~RUBY)
+      class ApiController < CoolerApiController; end
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/mavenlint/use_application_controller_spec.rb
+++ b/spec/rubocop/cop/mavenlint/use_application_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RuboCop::Cop::Mavenlint::UseApplicationController do
     RUBY
   end
 
-  it 'passes when a controller inherits from an other class' do
+  it 'passes when a controller inherits from another class' do
     expect_no_offenses(<<~RUBY)
       class MyController < ApiController; end
     RUBY

--- a/spec/rubocop/cop/mavenlint/use_application_controller_spec.rb
+++ b/spec/rubocop/cop/mavenlint/use_application_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rubocop/cop/mavenlint/use_application_controller'
+require 'spec_helper'
+
+RSpec.describe RuboCop::Cop::Mavenlint::UseApplicationController do
+  let(:config) { RuboCop::Config.new }
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when a controller directly inherits from ActionController::Base' do
+    expect_offense(<<~RUBY)
+      class MyController < ActionController::Base; end
+                           ^^^^^^^^^^^^^^^^^^^^^^ Controllers should subclass `ApplicationController`.
+    RUBY
+  end
+
+  it 'passes when a controller inherits from ApplicationController' do
+    expect_no_offenses(<<~RUBY)
+      class MyController < ApplicationController; end
+    RUBY
+  end
+
+  it 'passes when a controller inherits from an other class' do
+    expect_no_offenses(<<~RUBY)
+      class MyController < ApiController; end
+    RUBY
+  end
+end


### PR DESCRIPTION
We want to make sure that all of our controllers are inheriting from application controller which ensures that they are logged in and a few more essential things to use mavenlink. 