### PR TITLE
Add rule to prevent using boolean literals as initial state for useState

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "publish-canary": "lerna publish --canary",
     "publish-packages": "lerna publish",
-    "test": "jest"
+    "test": "jest",
+    "test:debug": "node --inspect node_modules/.bin/jest --runInBand"
   },
   "devDependencies": {
     "@babel/core": "^7.2.0",

--- a/packages/eslint-plugin-mavenlint/rules/__tests__/no-use-state-boolean-spec.js
+++ b/packages/eslint-plugin-mavenlint/rules/__tests__/no-use-state-boolean-spec.js
@@ -1,0 +1,32 @@
+import { RuleTester } from 'eslint';
+import rule from '../no-use-state-boolean';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-use-state-boolean', rule, {
+  valid: [
+    // Inside of our custom useToggle hook
+    {
+      code: 'useState(true);',
+      filename: 'hooks/use-thing.js',
+    },
+    {
+      code: 'useState(false);',
+      filename: 'hooks/use-thing.js',
+    },
+  ],
+  invalid: [
+    // Inside of a react component with useState(true)
+    {
+      code: 'useState(true);',
+      filename: 'lib/components/foo.js*',
+      errors: [{ type: 'CallExpression' }],
+    },
+    // Inside of a react component with useState(false)
+    {
+      code: 'useState(false);',
+      filename: 'lib/components/foo.js*',
+      errors: [{ type: 'CallExpression' }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-mavenlint/rules/no-use-state-boolean.js
+++ b/packages/eslint-plugin-mavenlint/rules/no-use-state-boolean.js
@@ -1,0 +1,30 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'prevent using booleans with useState',
+      category: 'Best Practices'
+    }
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const path = context.getFilename();
+        // return if we are in a custom hook
+        if(path.includes('hooks') && path.includes('use-')) { return; }
+
+        // return unless the callee is useState
+        if(node.callee.name !== 'useState') { return; }
+
+        const initialState = node.arguments[0];
+        if(initialState) {
+          if(initialState.type === 'Literal' && (initialState.value === true || initialState.value === false)) {
+            context.report({
+              node,
+              message: 'Boolean literal in useState. Use useToggle instead. See https://github.com/mavenlink/welcome/wiki/Lint-Errors#no-use-state-boolean',
+            });
+          }
+        }
+      }
+    }
+  }
+};


### PR DESCRIPTION
Co-authored-by: Eli Sullivan <esullivan@mavenlink.com>

This is a naive rule that prevents `useState(true)` and `useState(false)`. Hopefully no one is using an identifier `useState` outside of the `useState` hook that react provides. We did a global search and it doesn't look like it.

The idea is to push people to use `useToggle` instead.