### PR TITLE
Create rule to prevent direct invocation of FactoryBot

### DIFF
--- a/lib/rubocop/cop/mavenlint/direct_factory_bot_invocation.rb
+++ b/lib/rubocop/cop/mavenlint/direct_factory_bot_invocation.rb
@@ -1,0 +1,27 @@
+require 'rubocop'
+
+module RuboCop
+  module Cop
+    module Mavenlint
+      class DirectFactoryBotInvocation < RuboCop::Cop::Cop
+        MSG = 'Direct calls to FactoryBot should be replaced with Mavenlink::ModelFactories calls'.freeze
+        FACTORY_BOT_METHODS = %i(create build)
+
+        def_node_matcher :factory_bot_direct_usage, <<~PATTERN
+          (send
+            (const ... :FactoryBot) #factory_bot_method? ...)
+        PATTERN
+
+        def on_send(node)
+          return unless factory_bot_direct_usage(node)
+
+          add_offense(node, message: MSG)
+        end
+
+        def factory_bot_method?(symbol)
+          FACTORY_BOT_METHODS.include?(symbol)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/mavenlint/direct_factory_bot_invocation_spec.rb
+++ b/spec/rubocop/cop/mavenlint/direct_factory_bot_invocation_spec.rb
@@ -1,0 +1,21 @@
+require 'rubocop/cop/mavenlint/direct_factory_bot_invocation'
+require 'spec_helper'
+
+RSpec.describe RuboCop::Cop::Mavenlint::DirectFactoryBotInvocation do
+  let(:config) { RuboCop::Config.new }
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when FactoryBot.create is used' do
+    expect_offense(<<~RUBY)
+      FactoryBot.create(:maven_participation, foo: 'bar')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Direct calls to FactoryBot should be replaced with Mavenlink::ModelFactories calls
+    RUBY
+  end
+
+  it 'registers an offense when FactoryBot.build is used' do
+    expect_offense(<<~RUBY)
+      FactoryBot.build(:maven_participation, foo: 'bar')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Direct calls to FactoryBot should be replaced with Mavenlink::ModelFactories calls
+    RUBY
+  end
+end


### PR DESCRIPTION
This [PR](https://github.com/mavenlink/mavenlink/pull/24473) Removes runtime detection of `FactoryBot` invocations (because it is slow). So we can do it at lint time.