### PR TITLE
Handle pluralized account

### DIFF
--- a/lib/rubocop/cop/mavenlint/no_dependent_destroy_account.rb
+++ b/lib/rubocop/cop/mavenlint/no_dependent_destroy_account.rb
@@ -20,10 +20,11 @@ module RuboCop
 
         ASSOCIATIONS = %i[belongs_to has_many has_one has_and_belongs_to_many].freeze
         DEPENDENT_DESCTRUCTIVES = %i[destroy destroy_async delete delete_all].freeze
+        PROTECTED_MODELS = %i[account accounts]
 
         def_node_matcher :dangerous_account_association?, <<~PATTERN
           (send nil? #association?
-            (sym :account)
+            (sym #protected_model?)
             (hash
               _
               (pair
@@ -44,6 +45,10 @@ module RuboCop
 
         def destructive?(symbol)
           DEPENDENT_DESCTRUCTIVES.include?(symbol)
+        end
+
+        def protected_model?(symbol)
+          PROTECTED_MODELS.include?(symbol)
         end
       end
     end

--- a/spec/rubocop/cop/mavenlint/no_dependent_destroy_account_spec.rb
+++ b/spec/rubocop/cop/mavenlint/no_dependent_destroy_account_spec.rb
@@ -5,26 +5,28 @@ RSpec.describe RuboCop::Cop::Mavenlint::NoDependentDestroyAccount do
   let(:config) { RuboCop::Config.new }
   subject(:cop) { described_class.new(config) }
 
-  described_class::ASSOCIATIONS.each do |association|
-    described_class::DEPENDENT_DESCTRUCTIVES.each do |destructive|
-      it "registers an offense when #{association} :account has dependent: :#{destructive} option" do
-        message = " Do not add an association to account with dependent destroy. The destroy should go on the other side of the association. If you are sure the dependent action should be on this side of the association use dependent: :nullify See https://guides.rubyonrails.org/association_basics.html#options-for-belongs-to-dependent"
-        ruby_code = "#{association} :account, inverse_of: :foo, dependent: :#{destructive}, autosave: true"
-
-        message = message.rjust(ruby_code.length + message.length, '^')
-        expect_offense(<<~RUBY)
-          #{ruby_code}
-          #{message}
-        RUBY
-      end
-    end
-
+  [:account, :accounts].each do |model|
     described_class::ASSOCIATIONS.each do |association|
       described_class::DEPENDENT_DESCTRUCTIVES.each do |destructive|
         it "registers an offense when #{association} :account has dependent: :#{destructive} option" do
-          ruby_code = "#{association} :other_model, inverse_of: :foo, dependent: :#{destructive}, autosave: true"
+          message = " Do not add an association to account with dependent destroy. The destroy should go on the other side of the association. If you are sure the dependent action should be on this side of the association use dependent: :nullify See https://guides.rubyonrails.org/association_basics.html#options-for-belongs-to-dependent"
+          ruby_code = "#{association} :#{model}, inverse_of: :foo, dependent: :#{destructive}, autosave: true"
 
-          expect_no_offenses(ruby_code)
+          message = message.rjust(ruby_code.length + message.length, '^')
+          expect_offense(<<~RUBY)
+            #{ruby_code}
+            #{message}
+          RUBY
+        end
+      end
+
+      described_class::ASSOCIATIONS.each do |association|
+        described_class::DEPENDENT_DESCTRUCTIVES.each do |destructive|
+          it "registers an offense when #{association} :account has dependent: :#{destructive} option" do
+            ruby_code = "#{association} :other_model, inverse_of: :foo, dependent: :#{destructive}, autosave: true"
+
+            expect_no_offenses(ruby_code)
+          end
         end
       end
     end


### PR DESCRIPTION
Handles pluarlized account for association  methods that allow for it

ex: `has_many :accounts, dependent: :destroy`
