### PR TITLE
Dissallow all dependent options on account associations

### DIFF
--- a/lib/rubocop/cop/mavenlint/no_dependent_destroy_account.rb
+++ b/lib/rubocop/cop/mavenlint/no_dependent_destroy_account.rb
@@ -16,10 +16,9 @@ module RuboCop
       # Allowing deletion of account through active record associations can cause cascading data deletions. Account
       # is a root object and shouldn't be deleted via active record associations
       class NoDependentDestroyAccount < RuboCop::Cop::Cop
-        MSG = 'Do not add an association to account with dependent destroy. The destroy should go on the other side of the association. If you are sure the dependent action should be on this side of the association use dependent: :nullify See https://guides.rubyonrails.org/association_basics.html#options-for-belongs-to-dependent'
+        MSG = 'Do not add an association to account with dependent destroy. The destroy should go on the other side of the association. See https://guides.rubyonrails.org/association_basics.html#options-for-belongs-to-dependent'
 
         ASSOCIATIONS = %i[belongs_to has_many has_one has_and_belongs_to_many].freeze
-        DEPENDENT_DESCTRUCTIVES = %i[destroy destroy_async delete delete_all].freeze
         PROTECTED_MODELS = %i[account accounts].freeze
 
         def_node_matcher :dangerous_direct_account_association?, <<~PATTERN
@@ -28,7 +27,7 @@ module RuboCop
             (hash
               <(pair
                 (sym :dependent)
-                (sym #destructive?))
+                (sym ...))
               ...>
             ))
         PATTERN
@@ -39,7 +38,7 @@ module RuboCop
             (hash
               <(pair
                 (sym :dependent)
-                (sym #destructive?))
+                (sym ...))
               (pair
                 (sym :class_name)
                 (str "Account"))
@@ -57,10 +56,6 @@ module RuboCop
 
         def association?(symbol)
           ASSOCIATIONS.include?(symbol)
-        end
-
-        def destructive?(symbol)
-          DEPENDENT_DESCTRUCTIVES.include?(symbol)
         end
 
         def protected_model?(symbol)

--- a/spec/rubocop/cop/mavenlint/no_dependent_destroy_account_spec.rb
+++ b/spec/rubocop/cop/mavenlint/no_dependent_destroy_account_spec.rb
@@ -7,10 +7,9 @@ RSpec.describe RuboCop::Cop::Mavenlint::NoDependentDestroyAccount do
   let(:config) { RuboCop::Config.new }
   subject(:cop) { described_class.new(config) }
 
-  DEPENDENT_DESCTRUCTIVES = %i[destroy destroy_async delete delete_all nullify].freeze
-
   described_class::ASSOCIATIONS.each do |association|
-    DEPENDENT_DESCTRUCTIVES.each do |destructive|
+    dependent_destructives = %i[destroy destroy_async delete delete_all nullify]
+    dependent_destructives.each do |destructive|
       %i[account accounts].each do |model|
         it "registers an offense when #{association} :account has dependent: :#{destructive} option" do
           message = ' Do not add an association to account with dependent destroy. The destroy should go on the other side of the association. See https://guides.rubyonrails.org/association_basics.html#options-for-belongs-to-dependent'

--- a/spec/rubocop/cop/mavenlint/no_dependent_destroy_account_spec.rb
+++ b/spec/rubocop/cop/mavenlint/no_dependent_destroy_account_spec.rb
@@ -7,11 +7,13 @@ RSpec.describe RuboCop::Cop::Mavenlint::NoDependentDestroyAccount do
   let(:config) { RuboCop::Config.new }
   subject(:cop) { described_class.new(config) }
 
+  DEPENDENT_DESCTRUCTIVES = %i[destroy destroy_async delete delete_all nullify].freeze
+
   described_class::ASSOCIATIONS.each do |association|
-    described_class::DEPENDENT_DESCTRUCTIVES.each do |destructive|
+    DEPENDENT_DESCTRUCTIVES.each do |destructive|
       %i[account accounts].each do |model|
         it "registers an offense when #{association} :account has dependent: :#{destructive} option" do
-          message = ' Do not add an association to account with dependent destroy. The destroy should go on the other side of the association. If you are sure the dependent action should be on this side of the association use dependent: :nullify See https://guides.rubyonrails.org/association_basics.html#options-for-belongs-to-dependent'
+          message = ' Do not add an association to account with dependent destroy. The destroy should go on the other side of the association. See https://guides.rubyonrails.org/association_basics.html#options-for-belongs-to-dependent'
           ruby_code = "#{association} :#{model}, inverse_of: :foo, dependent: :#{destructive}, autosave: true"
 
           message = message.rjust(ruby_code.length + message.length, '^')
@@ -33,14 +35,14 @@ RSpec.describe RuboCop::Cop::Mavenlint::NoDependentDestroyAccount do
   it 'protects class name Account from dependent: :destroy' do
     expect_offense(<<~RUBY)
       belongs_to :invitee_account, dependent: :destroy, class_name: "Account"
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not add an association to account with dependent destroy. The destroy should go on the other side of the association. If you are sure the dependent action should be on this side of the association use dependent: :nullify See https://guides.rubyonrails.org/association_basics.html#options-for-belongs-to-dependent
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not add an association to account with dependent destroy. The destroy should go on the other side of the association. See https://guides.rubyonrails.org/association_basics.html#options-for-belongs-to-dependent
     RUBY
   end
 
   it 'handles various args' do
     expect_offense(<<~RUBY)
       belongs_to :account, dependent: :destroy
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not add an association to account with dependent destroy. The destroy should go on the other side of the association. If you are sure the dependent action should be on this side of the association use dependent: :nullify See https://guides.rubyonrails.org/association_basics.html#options-for-belongs-to-dependent
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not add an association to account with dependent destroy. The destroy should go on the other side of the association. See https://guides.rubyonrails.org/association_basics.html#options-for-belongs-to-dependent
     RUBY
   end
 end


### PR DESCRIPTION
Previously `dependent: :nullify` was still allowed, but this is destructive as well, see: https://guides.rubyonrails.org/association_basics.html#options-for-belongs-to-dependent

While nullify isn't specified for belongs_to associations still makes sense to dissallow all dependent options for account associations