### PR TITLE
Add rule to prevent dependent option on `belongs_to` associations

### DIFF
--- a/lib/rubocop/cop/mavenlint/belongs_to_dependent_option.rb
+++ b/lib/rubocop/cop/mavenlint/belongs_to_dependent_option.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+
+module RuboCop
+  module Cop
+    module Mavenlint
+      # Identify usages of active record association `belongs_to` with the dependent option
+      #
+      # For example
+      #
+      #   class SomeModel
+      #     belongs_to :workspace, dependent: :destroy
+      #   end
+      #
+      # It is advised to put the dependent option on the other side of the association
+      class BelongsToDependentOption < RuboCop::Cop::Cop
+        MSG = 'Do not use the dependent option with belongs_to associations. The option should go on the other side of the association. See https://guides.rubyonrails.org/association_basics.html#options-for-belongs-to-dependent'
+
+        def_node_matcher :bad_belongs_to?, <<~PATTERN
+          (send nil? :belongs_to
+            (sym ...)
+            (hash
+              <(pair
+                (sym :dependent)
+                (sym ...))
+              ...>
+            ))
+        PATTERN
+
+        def on_send(node)
+          return unless bad_belongs_to?(node)
+
+          add_offense(node, message: MSG)
+        end
+      end
+    end
+  end
+end
+

--- a/lib/rubocop/cop/mavenlint/belongs_to_dependent_option.rb
+++ b/lib/rubocop/cop/mavenlint/belongs_to_dependent_option.rb
@@ -37,4 +37,3 @@ module RuboCop
     end
   end
 end
-

--- a/spec/rubocop/cop/mavenlint/belongs_to_dependent_option_spec.rb
+++ b/spec/rubocop/cop/mavenlint/belongs_to_dependent_option_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rubocop/cop/mavenlint/belongs_to_dependent_option'
+require 'spec_helper'
+
+RSpec.describe RuboCop::Cop::Mavenlint::BelongsToDependentOption do
+  let(:config) { RuboCop::Config.new }
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when belongs_to is invoked with the dependent option' do
+    expect_offense(<<~RUBY)
+      belongs_to :workspace, inverse_of: :foo, dependent: :destroy_all, autosave: true
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use the dependent option with belongs_to associations. The option should go on the other side of the association. See https://guides.rubyonrails.org/association_basics.html#options-for-belongs-to-dependent
+    RUBY
+  end
+
+  it 'does not register an offense for other associations' do
+    expect_no_offenses(<<~RUBY)
+      has_one :workspace, inverse_of: :foo, dependent: :destroy, autosave: true
+    RUBY
+  end
+end


### PR DESCRIPTION
No `belongs_to` associations with `dependent` option