### PR TITLE
[IE-412] Allow the usage of mavenlint for newer versions of rubocop

### DIFF
--- a/lib/rubocop/cop/mavenlint/bigint_for_migration_keys.rb
+++ b/lib/rubocop/cop/mavenlint/bigint_for_migration_keys.rb
@@ -120,7 +120,7 @@ module RuboCop
 
         def get_table_id_type(node)
           id_type = node.children[3].children[0].children
-          return id_type[1].children[0] if id_type[0].children[0] == :id
+          id_type[1].children[0] if id_type[0].children[0] == :id
         rescue StandardError
           nil
         end

--- a/mavenlint.gemspec
+++ b/mavenlint.gemspec
@@ -2,16 +2,16 @@
 
 Gem::Specification.new do |s|
   s.name        = 'mavenlint'
-  s.version     = '1.5.0'
+  s.version     = '1.6.0'
   s.licenses    = ['MIT']
   s.summary     = 'Mavenlink Rubocop config'
-  s.authors     = ['Mavenlnk']
+  s.authors     = ['Mavenlink']
   s.email       = ['ahuth@mavenlink.com']
   s.files       = Dir['rubocop.yml', 'lib/**/*.rb']
   s.homepage    = 'https://github.com/mavenlink/mavenlint'
 
-  s.add_development_dependency 'rake', '~> 12'
-  s.add_development_dependency 'rspec', '3.7.0'
+  s.add_development_dependency 'rake', '12'
+  s.add_development_dependency 'rspec', '3.12'
   s.add_development_dependency 'rubocop', '1.31'
 
   s.required_ruby_version = '>= 2.7.5'

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -10,7 +10,7 @@ Lint/DuplicateMethods:
   Enabled: true
 
 # Enforce not duplicating hash keys.
-Lint/DuplicatedKey:
+Lint/DuplicateHashKey:
   Enabled: true
 
 # Ensure that we don't use `private` and `protected` on class methods, which doesn't work.


### PR DESCRIPTION
Fix a cop name to allow the usage of newer versions of Rubocop on Konekti.

We also fixed some information in the gemspec file like the version and development 

Original [error message](https://github.com/mavenlink/konekti/actions/runs/6474102141/job/17578555235)