### PR TITLE
remove dot-notation enforcement

### DIFF
--- a/packages/eslint-config-mavenlint/index.js
+++ b/packages/eslint-config-mavenlint/index.js
@@ -17,6 +17,7 @@ module.exports = {
     'arrow-body-style': 'off',
     'arrow-parens': 'off',
     'func-names': 'off',
+    'dot-notation': 'off',
     'no-console': 'error',
     'no-multiple-empty-lines': ["error", { "max": 1 }],
     'no-use-before-define': ["error", { "functions": false, "classes": true }],


### PR DESCRIPTION
This rule used to throw an error if you wrote `styles['header']`.

When the system forces the syntax to be inconsistent, eg. some usages must look like this `styles['header-main']` and some are `styles.header`, this really slows me down because I cannot keyboard multi-select refactor.

The same thing is true for function decl. syntax which is why I removed that enforcement awhile back.