### PR TITLE
Remove path filtering from github checks

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -7,8 +7,6 @@ on:
   pull_request:
     branches:
       - '**'
-    paths:
-      - '**.rb'
 
 jobs:
   rspec:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -7,8 +7,6 @@ on:
   pull_request:
     branches:
       - '**'
-    paths:
-      - '**.rb'
 
 jobs:
   rubocop:


### PR DESCRIPTION
 - The checks are required and so block PRs that dont have ruby file changes
 - The checks are super cheap, lets just run them
